### PR TITLE
Fix anon instrument mapping logic

### DIFF
--- a/notochord/notochord/data.py
+++ b/notochord/notochord/data.py
@@ -1,4 +1,3 @@
-import numpy as np
 from pathlib import Path
 import random
 
@@ -40,9 +39,8 @@ class MIDIDataset(Dataset):
 
         anon_melodic_start = 256
         anon_drum_start = anon_melodic_start + self.n_anon
-        anon_melodic = np.arange(anon_melodic_start, anon_melodic_start + self.n_anon)  # array of anon melodic programs
-        anon_drum = np.arange(anon_drum_start, anon_drum_start + self.n_anon)  # array of anon drum programs
-        np.random.shuffle(anon_melodic); np.random.shuffle(anon_drum)  # shuffle for random selection
+        anon_melodic = torch.randperm(self.n_anon) + anon_melodic_start  # array of anon melodic programs
+        anon_drum = torch.randperm(self.n_anon) + anon_drum_start  # array of anon drum programs
 
         i = 0
         for pr in unique_melodic:

--- a/notochord/notochord/data.py
+++ b/notochord/notochord/data.py
@@ -32,13 +32,13 @@ class MIDIDataset(Dataset):
         Randomly map instruments to eight additional ‘anonymous’ melodic and drum identities
         with a probability of 10% per instrument, without replacement.
 
-        The input program should contain melodic instruments from MIDI note numbers 1-128 and
-        drum instruments from 129-256. Anonymous instruments are mapped to subsequent note numbers.
+        The input program should contain melodic instruments from MIDI note numbers 0-127 and
+        drum instruments from 128-255. Anonymous instruments are mapped to subsequent note numbers.
         """
-        unique_melodic = program.masked_select(program<=128).unique()
-        unique_drum = program.masked_select(program>128).unique()
+        unique_melodic = program.masked_select(program<128).unique()
+        unique_drum = program.masked_select(program>=128).unique()
 
-        anon_melodic_start = 256 + 1
+        anon_melodic_start = 256
         anon_drum_start = anon_melodic_start + self.n_anon
         anon_melodic = np.arange(anon_melodic_start, anon_melodic_start + self.n_anon)  # array of anon melodic programs
         anon_drum = np.arange(anon_drum_start, anon_drum_start + self.n_anon)  # array of anon drum programs
@@ -81,10 +81,10 @@ class MIDIDataset(Dataset):
         )
         pitch = pitch + transpose
 
+        program = self._random_map_anonymous_instruments(program)
+
         # shift from 0-index to general MIDI 1-index; reserve 0 for start token
         program += 1
-
-        program = self._random_map_anonymous_instruments(program)
 
         time_margin = 1e-3 # hardcoded since it should match prep script
 

--- a/notochord/notochord/data.py
+++ b/notochord/notochord/data.py
@@ -81,6 +81,7 @@ class MIDIDataset(Dataset):
         )
         pitch = pitch + transpose
 
+        # randomly map instruments to 'anonymous melodic' and 'anonymous drum'
         program = self._random_map_anonymous_instruments(program)
 
         # shift from 0-index to general MIDI 1-index; reserve 0 for start token

--- a/notochord/notochord/data.py
+++ b/notochord/notochord/data.py
@@ -76,7 +76,7 @@ class MIDIDataset(Dataset):
         transpose_down = min(self.transpose, pitch.min().item())
         transpose_up = min(self.transpose, 127-pitch.max())
         transpose = (
-            random.randint(-transpose_down, transpose_up)   # why not torch.randint?
+            random.randint(-transpose_down, transpose_up)
             * (program<128) # don't transpose drums
         )
         pitch = pitch + transpose


### PR DESCRIPTION
Currently, the logic that randomly maps the anonymous melodic and drum identities allows the possibility for writing to the same anonymous instrument multiple times

This update ensures that anonymous instruments are randomly assigned without replacement. If all anonymous instruments (melodic or drum) are used up, no further anonymous instruments of that type (melodic or drum) will be added